### PR TITLE
Adds informational to triggers

### DIFF
--- a/src/data/triggers.json
+++ b/src/data/triggers.json
@@ -49,6 +49,7 @@
   "hit the ground running",
   "hold the fort",
   "ideat(e|ion)",
+  "informational",
   "it is what it is",
   "key takeaway(|s)",
   "learnings",


### PR DESCRIPTION
I keep getting asked to 'join an informational call', it seems like the word 'informational' should be a sin in any context . . .