### PR TITLE
Add word boundaries to "ooo"

### DIFF
--- a/src/data/triggers.json
+++ b/src/data/triggers.json
@@ -84,7 +84,7 @@
   "out of (pocket|the loop)",
   "out(side|\\sof) the box",
   "out of (|the )office",
-  "ooo",
+  "\\booo\\b",
   "outsource",
   "over the wall",
   "overseas",


### PR DESCRIPTION
So it doesn't trigger for "soooo", "oooooh", etc.