### PR TITLE
Removed downsizing from triggers

### DIFF
--- a/src/data/triggers.json
+++ b/src/data/triggers.json
@@ -36,7 +36,6 @@
   "deliverable",
   "do more with less",
   "(double|drill)(\\s|-|)down",
-  "down(\\s|)siz(e|ing)",
   "drinking the kool(\\s|-)aid",
   "ducks in a row",
   "dynamics",


### PR DESCRIPTION
I can't post my favourite gif due to the downsize trigger, and it's quite annoying.